### PR TITLE
Rename notificators to notifiers

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,9 +31,9 @@ import (
 	"time"
 
 	"gopkg.in/ini.v1"
-	"resticara/notificators/emailsender"
-	"resticara/notificators/matrixsender"
-	"resticara/notificators/telegramsender"
+	"resticara/notifiers/email"
+	"resticara/notifiers/matrix"
+	"resticara/notifiers/telegram"
 )
 
 type CommandInfo struct {
@@ -566,10 +566,10 @@ func main() {
 		printSummary(mailData, logwriter)
 
 		if config.SMTPEnabled {
-			emailSender := emailsender.SmtpEmailSender{}
+			emailNotifier := email.SmtpEmailNotifier{}
 			mailMessage := mailMessageBuffer.String()
 			mailSubject := mailData.StatusMessage + "---" + time.Now().Format(time.RFC1123)
-			emailConfig := emailsender.EmailConfig{
+			emailConfig := email.EmailConfig{
 				From:       config.From,
 				Username:   config.Username,
 				Password:   config.Pass,
@@ -580,7 +580,7 @@ func main() {
 				Body:       mailMessage,
 			}
 
-			if err := emailSender.Send(emailConfig); err != nil {
+			if err := emailNotifier.Send(emailConfig); err != nil {
 				fmt.Println(err)
 			} else {
 				fmt.Println("Email sent!")
@@ -590,9 +590,9 @@ func main() {
 		}
 
 		if config.MatrixEnabled {
-			matrixSender := matrixsender.GomatrixSender{}
+			matrixNotifier := matrix.GomatrixNotifier{}
 			message := mailData.StatusMessage + "---" + time.Now().Format(time.RFC1123) + "\n\n" + mailMessageBuffer.String()
-			matrixConfig := matrixsender.MatrixConfig{
+			matrixConfig := matrix.MatrixConfig{
 				Homeserver: config.MatrixServer,
 				Username:   config.MatrixUser,
 				Password:   config.MatrixPass,
@@ -600,7 +600,7 @@ func main() {
 				Message:    message,
 			}
 
-			if err := matrixSender.Send(matrixConfig); err != nil {
+			if err := matrixNotifier.Send(matrixConfig); err != nil {
 				fmt.Println(err)
 			} else {
 				fmt.Println("Matrix message sent!")
@@ -610,15 +610,15 @@ func main() {
 		}
 
 		if config.TelegramEnabled {
-			telegramSender := telegramsender.BotAPISender{}
+			telegramNotifier := telegram.BotAPINotifier{}
 			message := mailData.StatusMessage + "---" + time.Now().Format(time.RFC1123) + "\n\n" + mailMessageBuffer.String()
-			telegramConfig := telegramsender.TelegramConfig{
+			telegramConfig := telegram.TelegramConfig{
 				BotToken: config.TelegramToken,
 				ChatID:   config.TelegramChatID,
 				Message:  message,
 			}
 
-			if err := telegramSender.Send(telegramConfig); err != nil {
+			if err := telegramNotifier.Send(telegramConfig); err != nil {
 				fmt.Println(err)
 			} else {
 				fmt.Println("Telegram message sent!")

--- a/notifiers/email/email.go
+++ b/notifiers/email/email.go
@@ -1,4 +1,4 @@
-package emailsender
+package email
 
 import (
 	"fmt"
@@ -16,13 +16,13 @@ type EmailConfig struct {
 	Body       string
 }
 
-type EmailSender interface {
+type EmailNotifier interface {
 	Send(emailConfig EmailConfig) error
 }
 
-type SmtpEmailSender struct{}
+type SmtpEmailNotifier struct{}
 
-func (s SmtpEmailSender) Send(emailConfig EmailConfig) error {
+func (s SmtpEmailNotifier) Send(emailConfig EmailConfig) error {
 	message := "From: " + emailConfig.From + "\n" +
 		"To: " + emailConfig.To + "\n" +
 		"Subject: " + emailConfig.Subject + "\n\n" +

--- a/notifiers/matrix/matrix.go
+++ b/notifiers/matrix/matrix.go
@@ -1,4 +1,4 @@
-package matrixsender
+package matrix
 
 import (
 	"fmt"
@@ -14,13 +14,13 @@ type MatrixConfig struct {
 	Message    string
 }
 
-type MatrixSender interface {
+type MatrixNotifier interface {
 	Send(cfg MatrixConfig) error
 }
 
-type GomatrixSender struct{}
+type GomatrixNotifier struct{}
 
-func (s GomatrixSender) Send(cfg MatrixConfig) error {
+func (s GomatrixNotifier) Send(cfg MatrixConfig) error {
 	cli, err := gomatrix.NewClient(cfg.Homeserver, "", "")
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)

--- a/notifiers/telegram/telegram.go
+++ b/notifiers/telegram/telegram.go
@@ -1,4 +1,4 @@
-package telegramsender
+package telegram
 
 import (
 	"fmt"
@@ -12,13 +12,13 @@ type TelegramConfig struct {
 	Message  string
 }
 
-type TelegramSender interface {
+type TelegramNotifier interface {
 	Send(cfg TelegramConfig) error
 }
 
-type BotAPISender struct{}
+type BotAPINotifier struct{}
 
-func (s BotAPISender) Send(cfg TelegramConfig) error {
+func (s BotAPINotifier) Send(cfg TelegramConfig) error {
 	bot, err := tgbotapi.NewBotAPI(cfg.BotToken)
 	if err != nil {
 		return fmt.Errorf("failed to create bot: %w", err)


### PR DESCRIPTION
## Summary
- rename notificators directory to notifiers
- drop sender suffix from email, matrix and telegram notifiers
- update main to use new notifier names

## Testing
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b46050ca088320a7895aa05efa2ad3