### PR TITLE
feat: improve Matrix and Telegram messages

### DIFF
--- a/notifiers/matrix/matrix.go
+++ b/notifiers/matrix/matrix.go
@@ -41,7 +41,8 @@ func (s GomatrixNotifier) Send(cfg MatrixConfig) error {
 		// attempt to continue even if already joined
 	}
 
-	if _, err := cli.SendText(cfg.RoomID, cfg.Message); err != nil {
+	htmlMsg := gomatrix.GetHTMLMessage("m.text", cfg.Message)
+	if _, err := cli.SendMessageEvent(cfg.RoomID, "m.room.message", htmlMsg); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 	return nil

--- a/notifiers/telegram/telegram.go
+++ b/notifiers/telegram/telegram.go
@@ -24,6 +24,7 @@ func (s BotAPINotifier) Send(cfg TelegramConfig) error {
 		return fmt.Errorf("failed to create bot: %w", err)
 	}
 	msg := tgbotapi.NewMessage(cfg.ChatID, cfg.Message)
+	msg.ParseMode = tgbotapi.ModeHTML
 	if _, err := bot.Send(msg); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}

--- a/templates/matrix_template.html
+++ b/templates/matrix_template.html
@@ -1,0 +1,11 @@
+<h2><b>{{if eq .StatusMessage "Backup successful"}}✅ Backup successful{{else}}❌ Backup failed{{end}} for {{.HostID}}</b></h2>
+<br/>
+<i>{{.Date}}</i><br/><br/>
+{{range .Commands}}
+<b>📦 {{.CommandKey}}</b><br/>
+<pre><code>$ {{.BackupCmd}}
+{{.BackupOutput}}</code></pre>
+<pre><code>$ {{.ForgetCmd}}
+{{.ForgetOutput}}</code></pre>
+{{end}}
+<br/>

--- a/templates/telegram_template.html
+++ b/templates/telegram_template.html
@@ -1,10 +1,12 @@
-<b>{{if eq .StatusMessage "Backup successful"}}✅ Backup successful{{else}}❌ Backup failed{{end}} for {{.HostID}}</b><br/>
-<i>{{.Date}}</i><br/><br/>
+<b>{{if eq .StatusMessage "Backup successful"}}✅ Backup successful{{else}}❌ Backup failed{{end}} for {{.HostID}}</b>
+
+<i>{{.Date}}</i>
+
+
 {{range .Commands}}
-<b>📦 {{.CommandKey}}</b><br/>
+<b>📦 {{.CommandKey}}</b>
 <pre><code>$ {{.BackupCmd}}
 {{.BackupOutput}}</code></pre>
 <pre><code>$ {{.ForgetCmd}}
 {{.ForgetOutput}}</code></pre>
 {{end}}
-<br/>

--- a/templates/telegram_template.html
+++ b/templates/telegram_template.html
@@ -1,0 +1,10 @@
+<b>{{if eq .StatusMessage "Backup successful"}}✅ Backup successful{{else}}❌ Backup failed{{end}} for {{.HostID}}</b><br/>
+<i>{{.Date}}</i><br/><br/>
+{{range .Commands}}
+<b>📦 {{.CommandKey}}</b><br/>
+<pre><code>$ {{.BackupCmd}}
+{{.BackupOutput}}</code></pre>
+<pre><code>$ {{.ForgetCmd}}
+{{.ForgetOutput}}</code></pre>
+{{end}}
+<br/>


### PR DESCRIPTION
## Summary
- add chat-friendly HTML template for Matrix and Telegram messages
- send Matrix notifications with formatted HTML
- enable HTML parse mode for Telegram messages
- fix Telegram formatting by using a separate HTML template

## Testing
- `go vet ./...`
- `go build ./...`